### PR TITLE
Fix: Renaming template module from 'temp' to 'template'

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-gorote/gorote"
-	"github.com/go-gorote/temp/env"
+	"github.com/go-gorote/template/env"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/helmet"
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
 
-	_ "github.com/go-gorote/temp/docs"
+	_ "github.com/go-gorote/template/docs"
 )
 
 func gracefulShutdown(ctx context.Context, app *fiber.App) {

--- a/api/settings.go
+++ b/api/settings.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-gorote/auth"
 	"github.com/go-gorote/gorote"
-	"github.com/go-gorote/temp/app/example"
-	"github.com/go-gorote/temp/env"
+	"github.com/go-gorote/template/app/example"
+	"github.com/go-gorote/template/env"
 	"github.com/gofiber/fiber/v2"
 	"gorm.io/driver/postgres"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-gorote/temp
+module github.com/go-gorote/template
 
 go 1.24.0
 


### PR DESCRIPTION
This renaming follows the new repository name